### PR TITLE
LST 1606 edit forecast extra rows

### DIFF
--- a/forecast/management/commands/clear_financial_codes.py
+++ b/forecast/management/commands/clear_financial_codes.py
@@ -1,0 +1,33 @@
+from django.core.management.base import BaseCommand
+
+from django.db import connection
+
+from forecast.models import FinancialCode
+
+class Command(BaseCommand):
+    help = "Delete all unused financial codes"
+
+    def handle(self, *args, **options):
+
+         # Use sql to delete the figure for performance reason.
+        # The sql is 1000 times faster than queryset.delete()
+        count_before = FinancialCode.objects.all().count()
+        with connection.cursor() as cursor:
+            # Remove financial codes not used by future forecast and budget
+            sql_delete = "DELETE FROM forecast_financialcode " \
+                         "WHERE ID NOT IN " \
+                         "(SELECT financial_code_id " \
+                         "FROM  forecast_forecastmonthlyfigure " \
+                         "UNION " \
+                         "SELECT financial_code_id " \
+                         "FROM  end_of_month_monthlytotalbudget " \
+                         "UNION " \
+                         "SELECT financial_code_id " \
+                         "FROM forecast_budgetmonthlyfigure);"
+            cursor.execute(sql_delete)
+        deleted_count = count_before - FinancialCode.objects.all().count()
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Deleted {deleted_count} unused financial codes."
+            )
+        )

--- a/forecast/management/commands/clear_financial_codes.py
+++ b/forecast/management/commands/clear_financial_codes.py
@@ -25,6 +25,9 @@ class Command(BaseCommand):
                 "FROM  end_of_month_monthlytotalbudget "
                 "UNION "
                 "SELECT financial_code_id "
+                "FROM  end_of_month_monthlyoutturn "
+                "UNION "
+                "SELECT financial_code_id "
                 "FROM forecast_budgetmonthlyfigure);"
             )
             cursor.execute(sql_delete)

--- a/forecast/management/commands/clear_financial_codes.py
+++ b/forecast/management/commands/clear_financial_codes.py
@@ -4,30 +4,31 @@ from django.db import connection
 
 from forecast.models import FinancialCode
 
+
 class Command(BaseCommand):
     help = "Delete all unused financial codes"
 
     def handle(self, *args, **options):
 
-         # Use sql to delete the figure for performance reason.
+        # Use sql to delete the figure for performance reason.
         # The sql is 1000 times faster than queryset.delete()
         count_before = FinancialCode.objects.all().count()
         with connection.cursor() as cursor:
             # Remove financial codes not used by future forecast and budget
-            sql_delete = "DELETE FROM forecast_financialcode " \
-                         "WHERE ID NOT IN " \
-                         "(SELECT financial_code_id " \
-                         "FROM  forecast_forecastmonthlyfigure " \
-                         "UNION " \
-                         "SELECT financial_code_id " \
-                         "FROM  end_of_month_monthlytotalbudget " \
-                         "UNION " \
-                         "SELECT financial_code_id " \
-                         "FROM forecast_budgetmonthlyfigure);"
+            sql_delete = (
+                "DELETE FROM forecast_financialcode "
+                "WHERE ID NOT IN "
+                "(SELECT financial_code_id "
+                "FROM  forecast_forecastmonthlyfigure "
+                "UNION "
+                "SELECT financial_code_id "
+                "FROM  end_of_month_monthlytotalbudget "
+                "UNION "
+                "SELECT financial_code_id "
+                "FROM forecast_budgetmonthlyfigure);"
+            )
             cursor.execute(sql_delete)
         deleted_count = count_before - FinancialCode.objects.all().count()
         self.stdout.write(
-            self.style.SUCCESS(
-                f"Deleted {deleted_count} unused financial codes."
-            )
+            self.style.SUCCESS(f"Deleted {deleted_count} unused financial codes.")
         )

--- a/forecast/management/commands/clear_financial_codes.py
+++ b/forecast/management/commands/clear_financial_codes.py
@@ -14,7 +14,7 @@ class Command(BaseCommand):
         # The sql is 1000 times faster than queryset.delete()
         count_before = FinancialCode.objects.all().count()
         with connection.cursor() as cursor:
-            # Remove financial codes not used by future forecast and budget
+            # Remove financial codes not used
             sql_delete = (
                 "DELETE FROM forecast_financialcode "
                 "WHERE ID NOT IN "

--- a/forecast/management/commands/clear_forecast.py
+++ b/forecast/management/commands/clear_forecast.py
@@ -105,6 +105,13 @@ class Command(BaseCommand):
             )
             cursor.execute(sql_delete)
 
+            sql_delete = (
+                f"DELETE FROM end_of_month_monthlyoutturn "
+                f"WHERE financial_year_id = {current_year} "
+                f"OR financial_year_id IS NULL;"
+            )
+            cursor.execute(sql_delete)
+
             # Delete archived forecasts for future years
             sql_delete = (
                 "DELETE FROM forecast_forecastmonthlyfigure "

--- a/forecast/management/commands/clear_forecast.py
+++ b/forecast/management/commands/clear_forecast.py
@@ -1,5 +1,7 @@
+from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError
+
 
 from django.db import connection
 
@@ -117,19 +119,7 @@ class Command(BaseCommand):
             )
             cursor.execute(sql_delete)
 
-            # Don't remove financial codes still in use by future forecast and budget
-            sql_delete = "DELETE FROM forecast_financialcode " \
-                         "WHERE forecast_financialcode NOT IN " \
-                         "(SELECT forecast_financialcode " \
-                         "FROM  forecast_forecastmonthlyfigure " \
-                         "UNION " \
-                         "SELECT forecast_financialcode " \
-                         "FROM  end_of_month_monthlytotalbudget " \
-                         "UNION " \
-                         "SELECT forecast_financialcode " \
-                         "FROM forecast_budgetmonthlyfigure);"
-            cursor.execute(sql_delete)
-
+        call_command("clear_financial_codes")
         self.stdout.write(
             self.style.SUCCESS(
                 f"forecast/actual/budget figures for {current_year_display} "

--- a/forecast/test/test_clear_financial_codes.py
+++ b/forecast/test/test_clear_financial_codes.py
@@ -10,6 +10,7 @@ from forecast.models import (
 )
 from forecast.test.factories import FinancialCodeFactory
 
+
 class ClearForecastCommandNoArchiveTest(TestCase):
     def setUp(self):
         self.out = StringIO()

--- a/forecast/test/test_clear_financial_codes.py
+++ b/forecast/test/test_clear_financial_codes.py
@@ -1,0 +1,24 @@
+from io import StringIO
+
+from django.test import TestCase
+from django.core.management import call_command
+
+from end_of_month.test.test_utils import MonthlyFigureSetup
+
+from forecast.models import (
+    FinancialCode,
+)
+from forecast.test.factories import FinancialCodeFactory
+
+class ClearForecastCommandNoArchiveTest(TestCase):
+    def setUp(self):
+        self.out = StringIO()
+        init_data = MonthlyFigureSetup()
+        init_data.setup_forecast()
+        init_data.setup_budget()
+        FinancialCodeFactory()
+
+    def test_dont_remove_in_use(self):
+        assert FinancialCode.objects.all().count() == 2
+        call_command("clear_financial_codes")
+        assert FinancialCode.objects.all().count() == 1

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -478,4 +478,5 @@ Download MI
 type="submit
 role="alert
 download_budget_name
+clear_financial_codes
 


### PR DESCRIPTION
Create command to delete unused financial codes.
The financial codes were not deleted at the end of the financial year, because of a bug in the deletion.
Running the new command fix the error found by the user.