### PR TITLE
Hotfix/lst 1682 edit cost centre 0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/uktrade/pii-secret-check-hooks
-    rev: 0.0.0.34
+    rev: 0.0.0.35
     hooks:
     -   id: pii_secret_filename
         files: ''

--- a/forecast/test/test_edit_forecast_views.py
+++ b/forecast/test/test_edit_forecast_views.py
@@ -330,11 +330,12 @@ class ChooseCostCentreTest(BaseTestCase):
             200,
         )
 
+
 class EditCostCentre000Test(BaseTestCase):
     def setUp(self):
         self.client.force_login(self.test_user)
 
-        self.cost_centre_code = '000001'
+        self.cost_centre_code = "000001"
         self.cost_centre = CostCentreFactory.create(
             cost_centre_code=self.cost_centre_code
         )
@@ -350,10 +351,6 @@ class EditCostCentre000Test(BaseTestCase):
         resp = self.client.get(edit_forecast_url)
 
         self.assertEqual(resp.status_code, 200)
-
-
-
-
 
 
 class EditForecastLockTest(BaseTestCase):

--- a/forecast/test/test_edit_forecast_views.py
+++ b/forecast/test/test_edit_forecast_views.py
@@ -330,6 +330,31 @@ class ChooseCostCentreTest(BaseTestCase):
             200,
         )
 
+class EditCostCentre000Test(BaseTestCase):
+    def setUp(self):
+        self.client.force_login(self.test_user)
+
+        self.cost_centre_code = '000001'
+        self.cost_centre = CostCentreFactory.create(
+            cost_centre_code=self.cost_centre_code
+        )
+
+    def test_choose_cost_centre(self):
+        assign_perm("change_costcentre", self.test_user, self.cost_centre)
+
+        edit_forecast_url = reverse(
+            "edit_forecast", kwargs={"cost_centre_code": self.cost_centre_code}
+        )
+
+        # Should be allowed
+        resp = self.client.get(edit_forecast_url)
+
+        self.assertEqual(resp.status_code, 200)
+
+
+
+
+
 
 class EditForecastLockTest(BaseTestCase):
     def setUp(self):

--- a/forecast/utils/edit_helpers.py
+++ b/forecast/utils/edit_helpers.py
@@ -45,6 +45,7 @@ class IncorrectDecimalFormatException(Exception):
 
 logger = logging.getLogger(__name__)
 
+
 def formatted_cost_centre_code(cost_centre_code):
     # The edit views expect the cost centre as an integer, so they strip the leading 0
     # from the cost centre code.

--- a/forecast/utils/edit_helpers.py
+++ b/forecast/utils/edit_helpers.py
@@ -45,6 +45,14 @@ class IncorrectDecimalFormatException(Exception):
 
 logger = logging.getLogger(__name__)
 
+def formatted_cost_centre_code(cost_centre_code):
+    # The edit views expect the cost centre as an integer, so they strip the leading 0
+    # from the cost centre code.
+    # But the cost centre in the database is stored as a string , 6 char long,
+    # padded with leading 0
+    # This function returns the cost centre code in the expected format.
+    return str(cost_centre_code).zfill(6)
+
 
 def set_monthly_figure_amount(cost_centre_code, cell_data, financial_year):  # noqa C901
     start_period = FinancialPeriod.financial_period_info.actual_month() + 1

--- a/forecast/views/base.py
+++ b/forecast/views/base.py
@@ -70,7 +70,8 @@ class CostCentrePermissionTest(UserPassesTestMixin):
             raise NoCostCentreCodeInURLError("No cost centre code provided in URL")
 
         current_financial_year = get_current_financial_year()
-        self.cost_centre_code = formatted_cost_centre_code(self.kwargs["cost_centre_code"])
+        self.cost_centre_code = \
+            formatted_cost_centre_code(self.kwargs["cost_centre_code"])
 
         if "financial_year" in self.kwargs:
             self.financial_year = int(self.kwargs["financial_year"])

--- a/forecast/views/base.py
+++ b/forecast/views/base.py
@@ -17,6 +17,7 @@ from forecast.utils.access_helpers import (
     can_future_forecast_be_edited,
     can_view_forecasts,
 )
+from forecast.utils.edit_helpers import formatted_cost_centre_code
 from forecast.utils.query_fields import (
     SHOW_COSTCENTRE,
     SHOW_DIRECTORATE,
@@ -69,7 +70,8 @@ class CostCentrePermissionTest(UserPassesTestMixin):
             raise NoCostCentreCodeInURLError("No cost centre code provided in URL")
 
         current_financial_year = get_current_financial_year()
-        self.cost_centre_code = self.kwargs["cost_centre_code"]
+        self.cost_centre_code = formatted_cost_centre_code(self.kwargs["cost_centre_code"])
+
         if "financial_year" in self.kwargs:
             self.financial_year = int(self.kwargs["financial_year"])
         else:

--- a/forecast/views/edit_forecast.py
+++ b/forecast/views/edit_forecast.py
@@ -42,8 +42,8 @@ from forecast.utils.edit_helpers import (
     TooManyMatchException,
     check_cols_match,
     check_row_match,
-    set_monthly_figure_amount,
     formatted_cost_centre_code,
+    set_monthly_figure_amount,
 )
 from forecast.utils.query_fields import edit_forecast_order
 from forecast.views.base import (

--- a/forecast/views/edit_forecast.py
+++ b/forecast/views/edit_forecast.py
@@ -43,6 +43,7 @@ from forecast.utils.edit_helpers import (
     check_cols_match,
     check_row_match,
     set_monthly_figure_amount,
+    formatted_cost_centre_code,
 )
 from forecast.utils.query_fields import edit_forecast_order
 from forecast.views.base import (
@@ -120,8 +121,7 @@ class AddRowView(
         if "cost_centre_code" not in self.kwargs:
             raise NoCostCentreCodeInURLError("No cost centre code provided in URL")
 
-        self.cost_centre_code = self.kwargs["cost_centre_code"]
-
+        self.cost_centre_code = formatted_cost_centre_code(self.kwargs["cost_centre_code"])
         if "financial_year" not in self.kwargs:
             raise NoFinancialYearInURLError("No financial year provided in URL")
 

--- a/forecast/views/edit_forecast.py
+++ b/forecast/views/edit_forecast.py
@@ -121,7 +121,9 @@ class AddRowView(
         if "cost_centre_code" not in self.kwargs:
             raise NoCostCentreCodeInURLError("No cost centre code provided in URL")
 
-        self.cost_centre_code = formatted_cost_centre_code(self.kwargs["cost_centre_code"])
+        self.cost_centre_code = formatted_cost_centre_code(
+            self.kwargs["cost_centre_code"]
+        )
         if "financial_year" not in self.kwargs:
             raise NoFinancialYearInURLError("No financial year provided in URL")
 


### PR DESCRIPTION
Selecting cost centre 000000 or 000001 for editing causes a crash.
This is caused by the code being passed to the edit page as an integer, without the leading 0.
