### PR TITLE
Budgets returned to data workspace are not correct

### DIFF
--- a/data_lake/test/test_mi_report/test_budget.py
+++ b/data_lake/test/test_mi_report/test_budget.py
@@ -13,4 +13,4 @@ class BudgetTests(DataLakeTesting):
 
         cols = rows[0].split(",")
         assert len(cols) == 16
-        assert len(rows) == 104
+        assert len(rows) == 146

--- a/data_lake/views/mi_report_views/budget.py
+++ b/data_lake/views/mi_report_views/budget.py
@@ -28,6 +28,8 @@ class MIReportBudgetDataSet(DataLakeViewSet, MIReportFieldList):
 
     def write_data(self, writer):
         self.filter_on_archived_period = True
+        # Sometimes budgets are set in the adjustment periods
+        self.exclude_adj_period = False
         self.write_queryset_data(writer, ReportBudgetArchivedData)
         self.filter_on_archived_period = False
         self.write_queryset_data(writer, ReportBudgetCurrentData)


### PR DESCRIPTION
Return all 13 periods when downloading budgets to data workspace.