### PR TITLE
add PROD_ALIAS to allowed hosts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
 
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-browser-tools:
           chrome-version: 114.0.5735.90
       - checkout
       - run: mkdir test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,7 @@ jobs:
           name: Run tests
           command: |
             pytest --ignore=node_modules --ignore=front_end --ignore=features --ignore=staticfiles -n 4
+      - run: python -m pip install webdriver-manager --upgrade
       - run:
           name: Run BDD tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
 
     steps:
       - browser-tools/install-browser-tools
+          chrome-version: 114.0.5735.90
       - checkout
       - run: mkdir test-reports
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,8 @@ jobs:
           POSTGRES_PASSWORD: postgres
 
     steps:
-      - browser-tools/install-browser-tools:
-          chrome-version: 114.0.5735.90
+      - run: sudo apt get
+      - browser-tools/install-browser-tools
       - checkout
       - run: mkdir test-reports
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,8 @@ jobs:
           POSTGRES_PASSWORD: postgres
 
     steps:
-      - browser-tools/install-browser-tools:
-          chrome-version: 116.0.5845.110
-          replace-existing: true
+      - run: sudo apt-get update
+      - browser-tools/install-browser-tools
       - checkout
       - run: mkdir test-reports
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,9 @@ jobs:
 
     steps:
       - run: sudo apt-get update
+      - browser-tools/install-chrome:
+          chrome-version: 116.0.5845.96 
+          replace-existing: true
       - browser-tools/install-browser-tools
       - checkout
       - run: mkdir test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,9 @@ jobs:
           POSTGRES_PASSWORD: postgres
 
     steps:
-      - run: sudo apt get
-      - browser-tools/install-browser-tools
+      - browser-tools/install-browser-tools:
+          chrome-version: 116.0.5845.110
+          replace-existing: true
       - checkout
       - run: mkdir test-reports
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.1 # /PS-IGNORE
+  browser-tools: circleci/browser-tools@1.4.5 # /PS-IGNORE
 jobs:
   build:
     docker:

--- a/config/settings/build.py
+++ b/config/settings/build.py
@@ -4,6 +4,7 @@ manage.py compilestatic --settings=config.settings.build
 """
 import os
 
+
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 
 SECRET_KEY = "dont-use-in-prod"

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -151,4 +151,3 @@ PROD_ALIAS = os.environ.get("PROD_ALIAS", None)
 
 if PROD_ALIAS:
     ALLOWED_HOSTS.append(PROD_ALIAS)
-    

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -146,9 +146,3 @@ SECURE_BROWSER_XSS_FILTER = True
 
 # Audit log middleware user field
 AUDIT_LOG_USER_FIELD = "username"
-
-# AWS Copilot prod web service host alias
-PROD_ALIAS = env("PROD_ALIAS")
-
-if PROD_ALIAS:
-    ALLOWED_HOSTS.append(PROD_ALIAS)

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -147,7 +147,7 @@ SECURE_BROWSER_XSS_FILTER = True
 AUDIT_LOG_USER_FIELD = "username"
 
 # AWS Copilot prod web service host alias
-PROD_ALIAS = os.environ.get("PROD_ALIAS", None)
+PROD_ALIAS = env("PROD_ALIAS")
 
 if PROD_ALIAS:
     ALLOWED_HOSTS.append(PROD_ALIAS)

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -6,6 +6,7 @@ from sentry_sdk.integrations.django import DjangoIntegration
 
 from .base import *  # noqa
 
+
 WHITENOISE_MANIFEST_STRICT = False
 
 MIDDLEWARE += [

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -145,3 +145,10 @@ SECURE_BROWSER_XSS_FILTER = True
 
 # Audit log middleware user field
 AUDIT_LOG_USER_FIELD = "username"
+
+# AWS Copilot prod web service host alias
+PROD_ALIAS = os.environ.get("PROD_ALIAS", None)
+
+if PROD_ALIAS:
+    ALLOWED_HOSTS.append(PROD_ALIAS)
+    


### PR DESCRIPTION
Currently we're seeing errors when deploying fft to a prod environment because the web svc manifest includes:

```
environments:
  dev:
    http:
      alias: v2.fft.dev.uktrade.digital
  hotfix:
    http:
      alias: v2.fft.hotfix.uktrade.digital
  prod-data:
    http:
      alias: v2.fft.prod-data.uktrade.digital
  prod:
    http:
      alias: v2.fft.trade.gov.uk
```
but the app code complains that `v2.fft.trade.gov.uk` is not listed under `ALLOWED_HOSTS`.

This change expects the fft-deploy web manifest to be updated to pass in an env var called `PROD_ALIAS.

