### PR TITLE
DWPF-1767 Improve new_finance_year command

### DIFF
--- a/config/settings/paas.py
+++ b/config/settings/paas.py
@@ -7,8 +7,7 @@ from .base import *
 
 
 # TODO (DWPF-1696): Remove ECS formatter
-# FIXME
-# LOGGING["handlers"]["console"]["formatter"] = "ecs"
+LOGGING["handlers"]["console"]["formatter"] = "ecs"
 
 if is_copilot():
     ALLOWED_HOSTS = setup_allowed_hosts(ALLOWED_HOSTS)

--- a/config/settings/paas.py
+++ b/config/settings/paas.py
@@ -7,7 +7,8 @@ from .base import *
 
 
 # TODO (DWPF-1696): Remove ECS formatter
-LOGGING["handlers"]["console"]["formatter"] = "ecs"
+# FIXME
+# LOGGING["handlers"]["console"]["formatter"] = "ecs"
 
 if is_copilot():
     ALLOWED_HOSTS = setup_allowed_hosts(ALLOWED_HOSTS)

--- a/forecast/admin.py
+++ b/forecast/admin.py
@@ -137,7 +137,7 @@ class FinancialCodeAdmin(AdminReadOnly):
         ("programme", RelatedDropdownFilter),
         ("analysis1_code", RelatedDropdownFilter),
         ("analysis2_code", RelatedDropdownFilter),
-        ("project_code,", RelatedDropdownFilter),
+        ("project_code", RelatedDropdownFilter),
     )
 
     def get_readonly_fields(self, request, obj=None):

--- a/forecast/management/commands/new_financial_year.py
+++ b/forecast/management/commands/new_financial_year.py
@@ -94,7 +94,7 @@ def pre_new_financial_year_checks() -> None:
     )
 
     if bool(problem_nacs):
-        problem_nac_ids = problem_nacs.values_list("natural_account_code", flat=True)
+        problem_nac_ids = [str(nac.natural_account_code) for nac in problem_nacs]
         raise NewFinancialYearError(
             f"Possible problem NACs found: {", ".join(problem_nac_ids)}"
         )

--- a/forecast/management/commands/new_financial_year.py
+++ b/forecast/management/commands/new_financial_year.py
@@ -29,10 +29,10 @@ class Command(CommandWithUserCheck):
         return True
 
     def handle_user(self, *args, **options):
-        try:
-            pre_new_financial_year_checks()
-        except NewFinancialYearError as err:
-            raise CommandError(str(err)) from err
+        # try:
+        #     pre_new_financial_year_checks()
+        # except NewFinancialYearError as err:
+        #     raise CommandError(str(err)) from err
 
         current_financial_year = get_current_financial_year()
         current_financial_year_display = get_year_display(current_financial_year)

--- a/forecast/management/commands/new_financial_year.py
+++ b/forecast/management/commands/new_financial_year.py
@@ -87,8 +87,9 @@ def pre_new_financial_year_checks() -> None:
     This function will raise `NewFinancialYearError` if any issues are found.
 
     Checks:
-        - Look for NACs with invalid economic budget codes.
+        - Look for used NACs with invalid economic budget codes.
     """
+    # It's possible this needs to be scoped to a financial year in the future.
     problem_nacs = FinancialCode.objects.exclude(
         natural_account_code__economic_budget_code__in=VALID_ECONOMIC_CODE_LIST
     )

--- a/forecast/management/commands/new_financial_year.py
+++ b/forecast/management/commands/new_financial_year.py
@@ -1,13 +1,13 @@
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
-from chartofaccountDIT.models import NaturalCode
 from core.utils.command_helpers import CommandWithUserCheck, get_no_answer
 from core.utils.generic_helpers import (
     create_financial_year_display,
     get_current_financial_year,
     get_year_display,
 )
+from forecast.models import FinancialCode
 from forecast.utils.import_helpers import VALID_ECONOMIC_CODE_LIST
 
 
@@ -29,10 +29,10 @@ class Command(CommandWithUserCheck):
         return True
 
     def handle_user(self, *args, **options):
-        # try:
-        #     pre_new_financial_year_checks()
-        # except NewFinancialYearError as err:
-        #     raise CommandError(str(err)) from err
+        try:
+            pre_new_financial_year_checks()
+        except NewFinancialYearError as err:
+            raise CommandError(str(err)) from err
 
         current_financial_year = get_current_financial_year()
         current_financial_year_display = get_year_display(current_financial_year)
@@ -89,8 +89,8 @@ def pre_new_financial_year_checks() -> None:
     Checks:
         - Look for NACs with invalid economic budget codes.
     """
-    problem_nacs = NaturalCode.objects.exclude(
-        economic_budget_code__in=VALID_ECONOMIC_CODE_LIST
+    problem_nacs = FinancialCode.objects.exclude(
+        natural_account_code__economic_budget_code__in=VALID_ECONOMIC_CODE_LIST
     )
 
     if bool(problem_nacs):


### PR DESCRIPTION
Whilst trying to run the `new_finance_year` command, we ran into some bad data that had made it's way into the database. What we found was a used financial code with a NAC that had an invalid economic budget code. To resolve the issue we fixed the data by changing the NAC's economic budget code.

This commit extends the `new_finance_year` command to detect this issue before changing the financial year. It also serves to document the issue we faced.