### PR TITLE
FFT-95 Optimise edit forecast database queries

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -283,7 +283,6 @@ MIDDLEWARE = [
     "core.no_cache_middleware.NoCacheMiddleware",
     "simple_history.middleware.HistoryRequestMiddleware",
     "axes.middleware.AxesMiddleware",
-    "core.middleware.DatabaseQueriesMiddleware",
     "core.middleware.CoreRequestDataMiddleware",
 ]
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -284,6 +284,7 @@ MIDDLEWARE = [
     "simple_history.middleware.HistoryRequestMiddleware",
     "axes.middleware.AxesMiddleware",
     "core.middleware.DatabaseQueriesMiddleware",
+    "core.middleware.CoreRequestDataMiddleware",
 ]
 
 AUTHENTICATION_BACKENDS = [

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -283,6 +283,7 @@ MIDDLEWARE = [
     "core.no_cache_middleware.NoCacheMiddleware",
     "simple_history.middleware.HistoryRequestMiddleware",
     "axes.middleware.AxesMiddleware",
+    "core.middleware.DatabaseQueriesMiddleware",
 ]
 
 AUTHENTICATION_BACKENDS = [

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -16,7 +16,7 @@ class DatabaseQueriesMiddleware:
 
         post_query_count = len(connection.queries)
         query_count = post_query_count - pre_query_count
-        # pprint(connection.queries)
+        pprint(connection.queries)
         print(f"Database queries {query_count}")
 
         # https://docs.sentry.io/platforms/python/performance/instrumentation/custom-instrumentation/#accessing-the-current-transaction

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,5 +1,7 @@
+from contextvars import ContextVar
 from pprint import pprint
 
+import sentry_sdk
 from django.db import connection
 
 
@@ -14,7 +16,29 @@ class DatabaseQueriesMiddleware:
 
         post_query_count = len(connection.queries)
         query_count = post_query_count - pre_query_count
-        pprint(connection.queries)
+        # pprint(connection.queries)
         print(f"Database queries {query_count}")
+
+        # https://docs.sentry.io/platforms/python/performance/instrumentation/custom-instrumentation/#accessing-the-current-transaction
+        transaction = sentry_sdk.Hub.current.scope.transaction
+
+        if transaction is not None:
+            transaction.set_tag("database.query_count", query_count)
+
+        return response
+
+
+_current_financial_year = ContextVar("current_financial_year", default=None)
+
+
+class CoreRequestDataMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+
+        response = self.get_response(request)
+
+        _current_financial_year.set(None)
 
         return response

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,34 +1,4 @@
-from contextvars import ContextVar
-from pprint import pprint
-
-import sentry_sdk
-from django.db import connection
-
-
-class DatabaseQueriesMiddleware:
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        pre_query_count = len(connection.queries)
-
-        response = self.get_response(request)
-
-        post_query_count = len(connection.queries)
-        query_count = post_query_count - pre_query_count
-        pprint(connection.queries)
-        print(f"Database queries {query_count}")
-
-        # https://docs.sentry.io/platforms/python/performance/instrumentation/custom-instrumentation/#accessing-the-current-transaction
-        transaction = sentry_sdk.Hub.current.scope.transaction
-
-        if transaction is not None:
-            transaction.set_tag("database.query_count", query_count)
-
-        return response
-
-
-_current_financial_year = ContextVar("current_financial_year", default=None)
+from core.utils.generic_helpers import get_current_financial_year
 
 
 class CoreRequestDataMiddleware:
@@ -36,9 +6,8 @@ class CoreRequestDataMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
+        request.current_financial_year = get_current_financial_year()
 
         response = self.get_response(request)
-
-        _current_financial_year.set(None)
 
         return response

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,3 +1,5 @@
+from pprint import pprint
+
 from django.db import connection
 
 
@@ -12,6 +14,7 @@ class DatabaseQueriesMiddleware:
 
         post_query_count = len(connection.queries)
         query_count = post_query_count - pre_query_count
+        pprint(connection.queries)
         print(f"Database queries {query_count}")
 
         return response

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,0 +1,17 @@
+from django.db import connection
+
+
+class DatabaseQueriesMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        pre_query_count = len(connection.queries)
+
+        response = self.get_response(request)
+
+        post_query_count = len(connection.queries)
+        query_count = post_query_count - pre_query_count
+        print(f"Database queries {query_count}")
+
+        return response

--- a/core/utils/generic_helpers.py
+++ b/core/utils/generic_helpers.py
@@ -3,15 +3,10 @@ import datetime
 from django.contrib.admin.models import CHANGE, LogEntry
 from django.contrib.contenttypes.models import ContentType
 
-from core.middleware import _current_financial_year
 from core.models import FinancialYear
 
 
 def get_current_financial_year():
-    # FIXME: decide if to include this
-    if var := _current_financial_year.get():
-        return var
-
     y = FinancialYear.objects.filter(current=True)
     if y:
         current_financial_year = y.last().financial_year
@@ -31,8 +26,6 @@ def get_current_financial_year():
             # year it is one year behind the
             # calendar year
             current_financial_year -= 1
-
-    _current_financial_year.set(current_financial_year)
 
     return current_financial_year
 

--- a/core/utils/generic_helpers.py
+++ b/core/utils/generic_helpers.py
@@ -1,4 +1,5 @@
 import datetime
+from contextvars import ContextVar
 
 from django.contrib.admin.models import CHANGE, LogEntry
 from django.contrib.contenttypes.models import ContentType
@@ -6,7 +7,14 @@ from django.contrib.contenttypes.models import ContentType
 from core.models import FinancialYear
 
 
+_current_financial_year = ContextVar("current_financial_year", default=None)
+
+
 def get_current_financial_year():
+    # FIXME: decide if to include this
+    if var := _current_financial_year.get():
+        return var
+
     y = FinancialYear.objects.filter(current=True)
     if y:
         current_financial_year = y.last().financial_year
@@ -26,6 +34,8 @@ def get_current_financial_year():
             # year it is one year behind the
             # calendar year
             current_financial_year -= 1
+
+    _current_financial_year.set(current_financial_year)
 
     return current_financial_year
 

--- a/core/utils/generic_helpers.py
+++ b/core/utils/generic_helpers.py
@@ -1,13 +1,10 @@
 import datetime
-from contextvars import ContextVar
 
 from django.contrib.admin.models import CHANGE, LogEntry
 from django.contrib.contenttypes.models import ContentType
 
+from core.middleware import _current_financial_year
 from core.models import FinancialYear
-
-
-_current_financial_year = ContextVar("current_financial_year", default=None)
 
 
 def get_current_financial_year():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
     depends_on:
       - db
       - redis
+    # Required for debuggers to work.
+    stdin_open: true
+    tty: true
 
   celery:
     image: fft/web:latest

--- a/forecast/serialisers.py
+++ b/forecast/serialisers.py
@@ -25,7 +25,7 @@ class ForecastMonthlyFigureSerializer(serializers.ModelSerializer):
         return obj.financial_period.financial_period_code
 
     def get_actual(self, obj):
-        if obj.financial_year_id > get_current_financial_year():
+        if obj.financial_year_id > self.context["current_financial_year"]:
             return False
         return obj.financial_period.actual_loaded
 
@@ -67,6 +67,7 @@ class FinancialCodeSerializer(serializers.ModelSerializer):
         return obj.natural_account_code.natural_account_code_description
 
     def get_budget(self, obj):
+        # FIXME: 400+ queries! try this as a prefetch similar to forecast or change to a lookup
         financial_year = self.context["financial_year"]
         budget = (
             BudgetMonthlyFigure.objects.values(

--- a/forecast/serialisers.py
+++ b/forecast/serialisers.py
@@ -67,6 +67,7 @@ class FinancialCodeSerializer(serializers.ModelSerializer):
         return obj.natural_account_code.natural_account_code_description
 
     def get_budget(self, obj):
+        return obj.yearly_budget_amount
         # FIXME: 400+ queries! try this as a prefetch similar to forecast or change to a lookup
         financial_year = self.context["financial_year"]
         budget = (

--- a/forecast/serialisers.py
+++ b/forecast/serialisers.py
@@ -1,8 +1,6 @@
 from django.db.models import Sum
 from rest_framework import serializers
 
-from core.utils.generic_helpers import get_current_financial_year
-
 from .models import BudgetMonthlyFigure, FinancialCode, ForecastMonthlyFigure
 
 

--- a/forecast/views/edit_forecast.py
+++ b/forecast/views/edit_forecast.py
@@ -471,7 +471,7 @@ class EditForecastView(
     def class_name(self):
         return "wide-table"
 
-    # FIXME: might be risky
+    # FIXME: Triple check this is safe
     @cached_property
     def cost_centre_details(self):
         cost_centre = CostCentre.objects.select_related("directorate__group").get(
@@ -532,7 +532,7 @@ class EditForecastView(
 
         return data
 
-    @property
+    @cached_property
     def future_year_display(self):
         if self._future_year_display is None:
             current_year = get_current_financial_year()

--- a/forecast/views/edit_forecast.py
+++ b/forecast/views/edit_forecast.py
@@ -1,7 +1,7 @@
-from functools import cached_property
 import json
 import logging
 import re
+from functools import cached_property
 
 from django.conf import settings
 from django.db import transaction

--- a/front_end/src/Util.js
+++ b/front_end/src/Util.js
@@ -32,10 +32,11 @@ function getCookie(name) {
     return cookieValue;
 }
 
+const NumberFormat = new Intl.NumberFormat('en-GB'); 
+
 export const formatValue = (value) => {
-    let nfObject = new Intl.NumberFormat('en-GB'); 
     let pounds = Math.round(value)
-    return nfObject.format(pounds); 
+    return NumberFormat.format(pounds); 
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "build": "vite build",
     "dev": "vite",
+    "preview": "vite preview",
     "postinstall": "npm run build"
   },
   "eslintConfig": {


### PR DESCRIPTION
I set out to improve the performance of the edit forecast page. On my local machine it took over 6 seconds just to fetch the initial HTML.

Our local dataset contains over 400 rows in the table on that page, so I suspected we had an n+1 database query problem. After some digging it turns out I was right and there were over 17,000 queries!

After a couple of days spent optimising code, mostly through the use of `select_related` and `prefetch_related`, I've managed to get the number of queries down to 13 and the page load time down to around 300ms!

Here is a brief list of the optimisations:
- apply `select_related` and `prefetch_related` where needed
- store the `current_financial_year` on the `request` object
- apply `cached_property` to view methods being used in the template
- pass the `current_financial_year` as context into the financial code serializer
- add budget amount annotation to queryset
- small javascript refactor to avoid needless object creation

There was a more ambitious optimising around the `current_financial_year` using a `ContextVar`, but I chose to leave it out and go with storing it on the request object as it's simpler.

The react code is now the bottleneck on that page :)