### PR TITLE
Tech debt: Fix warnings

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -7,5 +7,5 @@ urlpatterns = [
     path("", views.index, name="index"),
     path("logout", views.logout, name="logout"),
     path("accessibility", views.AccessibilityPageView.as_view(), name="accessibility"),
-    path("report/budget-report", views.budget_report, name="report:budget_report"),
+    path("report/budget-report", views.budget_report, name="budget_report"),
 ]

--- a/end_of_month/templatetags/download_permissions.py
+++ b/end_of_month/templatetags/download_permissions.py
@@ -1,9 +1,0 @@
-from django import template
-
-
-register = template.Library()
-
-
-@register.simple_tag
-def has_end_of_month_archive_permission(user):
-    return user.has_perm("forecast.can_archive_end_of_month")


### PR DESCRIPTION
Removed download_permissions.py for end of month as the file name clashed with an existing templatetags file and the code is no longer in use. `has_end_of_month_archive_permission` had been replaced by `has_end_of_month_archive_permissions`

Renamed report url as the colon caused an ambiguous name reference warning

- [x] JIRA ticket referenced in title
- [x] Title is clear and concise
- [x] Description gives any relevant detail
- [ ] Tests are up to date
- [ ] Documentation is up to date
