### PR TITLE
Handle empty vacancies/payroll

### DIFF
--- a/front_end/src/Components/EditPayroll/EditPayModifier/index.jsx
+++ b/front_end/src/Components/EditPayroll/EditPayModifier/index.jsx
@@ -2,7 +2,7 @@ import { monthsToTitleCase } from "../../../Util";
 
 const EditPayModifier = ({ data, onInputChange }) => {
   if (data.length === 0) {
-    return <p class="govuk-body">No modifiers set</p>;
+    return <p className="govuk-body">No modifiers set</p>;
   }
   return data.map((row, index) => (
     <div className="govuk-form-group" key={index}>

--- a/front_end/src/Components/EditPayroll/PayrollTable/index.jsx
+++ b/front_end/src/Components/EditPayroll/PayrollTable/index.jsx
@@ -10,6 +10,9 @@ export default function PayrollTable({
   onTogglePayPeriods,
   RowComponent,
 }) {
+  if (payroll.length === 0) {
+    return <p className="govuk-body">No data found</p>;
+  }
   return (
     <>
       <div className="scrollable">


### PR DESCRIPTION
If payroll or vacancy data is empty, display 'No data found' message, similar to Pay Modifiers tab
Fix class warning
