### PR TITLE
Add header for pay modifier to specify which modifier type

### DIFF
--- a/front_end/src/Components/EditPayroll/EditPayModifier/index.jsx
+++ b/front_end/src/Components/EditPayroll/EditPayModifier/index.jsx
@@ -4,8 +4,10 @@ const EditPayModifier = ({ data, onInputChange }) => {
   if (data.length === 0) {
     return <p className="govuk-body">No modifiers set</p>;
   }
+
   return data.map((row, index) => (
     <div className="govuk-form-group" key={index}>
+      <h3 className="govuk-heading-s">Attrition</h3>
       <table className="govuk-table">
         <thead className="govuk-table__head">
           <tr className="govuk-table__row">


### PR DESCRIPTION
Add a header to specify that the Pay Modifier is Attrition. In future, this will be dynamic based on what Pay Modifier is being displayed (Attrition / Pay Uplift)

- [ ] JIRA ticket referenced in title
- [x] Title is clear and concise
- [x] Description gives any relevant detail
- [ ] Tests are up to date
- [ ] Documentation is up to date
