### PR TITLE
FFT-143 Bring actuals into Edit Payroll forecast table

### DIFF
--- a/core/utils/generic_helpers.py
+++ b/core/utils/generic_helpers.py
@@ -111,9 +111,10 @@ def log_object_change(
 
 
 class PreviousMonths(TypedDict):
-    month_short_name = str
-    month_index = int
-    is_actual = bool
+    key: str
+    index: int
+    short_name: str
+    is_actual: bool
 
 
 def get_previous_months_data() -> Iterator[PreviousMonths]:
@@ -124,7 +125,8 @@ def get_previous_months_data() -> Iterator[PreviousMonths]:
     )
     for obj in qs:
         yield PreviousMonths(
-            month_short_name=obj.period_short_name,
-            month_index=obj.financial_period_code,
+            key=obj.period_short_name.lower(),
+            index=obj.financial_period_code,
+            short_name=obj.period_short_name,
             is_actual=obj.actual_loaded,
         )

--- a/forecast/models.py
+++ b/forecast/models.py
@@ -465,6 +465,43 @@ class FinancialCode(FinancialCodeAbstract, BaseModel):
         null=True,
     )
 
+    def as_key(self, **kwargs) -> str:
+        return self.build_str_key(
+            self.cost_centre_id,
+            self.natural_account_code_id,
+            self.programme_id,
+            self.analysis1_code_id,
+            self.analysis2_code_id,
+            self.project_code_id,
+            **kwargs,
+        )
+
+    @staticmethod
+    def build_str_key(
+        cost_centre_code: str,
+        nac: str,
+        programme: str,
+        analysis1: str | None = None,
+        analysis2: str | None = None,
+        project: str | None = None,
+        year: str | int | None = None,
+        period: str | int | None = None,
+        separator="/",
+    ) -> str:
+        return separator.join(
+            str(x) if x is not None else ""
+            for x in [
+                cost_centre_code,
+                nac,
+                programme,
+                analysis1,
+                analysis2,
+                project,
+                year,
+                period,
+            ]
+        )
+
     def human_readable_format(self):
         cost_centre = (
             f"(Cost Centre: {self.cost_centre.cost_centre_code}"

--- a/forecast/models.py
+++ b/forecast/models.py
@@ -466,6 +466,10 @@ class FinancialCode(FinancialCodeAbstract, BaseModel):
     )
 
     def as_key(self, **kwargs) -> str:
+        """Return as a key suitable for frontend use.
+
+        See `build_str_key` static method for examples.
+        """
         return self.build_str_key(
             self.cost_centre_id,
             self.natural_account_code_id,
@@ -488,6 +492,17 @@ class FinancialCode(FinancialCodeAbstract, BaseModel):
         period: str | int | None = None,
         separator="/",
     ) -> str:
+        """Return a key suitable for frontend use.
+
+        Mirrored by the javascript function `makeFinancialCodeKey`.
+
+        Examples:
+            With all arguments:
+            "888812/71111001/338887/1234/5678/0001/2024/02"
+
+            With minimal arguments:
+            "888812/71111001/338887/////"
+        """
         return separator.join(
             str(x) if x is not None else ""
             for x in [

--- a/front_end/src/Apps/Payroll.jsx
+++ b/front_end/src/Apps/Payroll.jsx
@@ -174,7 +174,9 @@ export default function Payroll() {
       </button>
       <ForecastTable
         forecast={allPayroll.forecast}
+        actuals={allPayroll.actuals}
         months={monthsToTitleCase}
+        previousMonths={allPayroll.previous_months}
       />
     </>
   );

--- a/front_end/src/Apps/Payroll.jsx
+++ b/front_end/src/Apps/Payroll.jsx
@@ -22,6 +22,7 @@ const initialPayrollState = {
   pay_modifiers: [],
   forecast: [],
   previous_months: [],
+  actuals: [],
 };
 
 export default function Payroll() {

--- a/front_end/src/Apps/Payroll.jsx
+++ b/front_end/src/Apps/Payroll.jsx
@@ -69,6 +69,30 @@ export default function Payroll() {
     () => allPayroll.employees.filter((payroll) => payroll.basic_pay <= 0),
     [allPayroll],
   );
+  const forecastAndActuals = useMemo(() => {
+    const total_results = [];
+    for (const item of allPayroll.forecast) {
+      let results = {
+        programme_code: item.programme_code,
+        natural_account_code: item.natural_account_code,
+        actuals_count: 0,
+      };
+      monthsToTitleCase.map((month, index) => {
+        if (allPayroll.previous_months[index].is_actual) {
+          results.actuals_count += 1;
+          // TODO: need to get cost centre somehow
+          results[month] =
+            allPayroll.actuals[
+              `888812-${item.natural_account_code}-${item.programme_code}-${month}`
+            ];
+        } else {
+          results[month] = item[month.toLowerCase()];
+        }
+      });
+      total_results.push(results);
+    }
+    return total_results;
+  }, [allPayroll]);
 
   // Handlers
   async function handleSavePayroll() {
@@ -172,12 +196,7 @@ export default function Payroll() {
       <button className="govuk-button" onClick={handleSavePayroll}>
         Save payroll
       </button>
-      <ForecastTable
-        forecast={allPayroll.forecast}
-        actuals={allPayroll.actuals}
-        months={monthsToTitleCase}
-        previousMonths={allPayroll.previous_months}
-      />
+      <ForecastTable forecast={forecastAndActuals} months={monthsToTitleCase} />
     </>
   );
 }

--- a/front_end/src/Apps/Payroll.jsx
+++ b/front_end/src/Apps/Payroll.jsx
@@ -14,7 +14,7 @@ import ToggleCheckbox from "../Components/Common/ToggleCheckbox";
 import ErrorSummary from "../Components/Common/ErrorSummary";
 import SuccessBanner from "../Components/Common/SuccessBanner";
 import ForecastTable from "../Components/EditPayroll/ForecastTable";
-import { monthsToTitleCase } from "../Util";
+import { makeFinancialCodeKey, monthsToTitleCase } from "../Util";
 
 const initialPayrollState = {
   employees: [],
@@ -24,6 +24,8 @@ const initialPayrollState = {
   previous_months: [],
   actuals: [],
 };
+const costCentreCode = window.costCentreCode;
+const financialYear = window.financialYear;
 
 export default function Payroll() {
   const [allPayroll, dispatch] = useReducer(
@@ -80,11 +82,13 @@ export default function Payroll() {
       monthsToTitleCase.map((month, index) => {
         if (allPayroll.previous_months[index].is_actual) {
           results.actuals_count += 1;
-          // TODO: need to get cost centre somehow
-          results[month] =
-            allPayroll.actuals[
-              `888812-${item.natural_account_code}-${item.programme_code}-${month}`
-            ];
+          const financialCodeKey = makeFinancialCodeKey(
+            costCentreCode,
+            item.natural_account_code,
+            item.programme_code,
+            { year: financialYear, period: index + 1 },
+          );
+          results[month] = allPayroll.actuals[financialCodeKey];
         } else {
           results[month] = item[month.toLowerCase()];
         }

--- a/front_end/src/Components/EditPayroll/ForecastTable/index.jsx
+++ b/front_end/src/Components/EditPayroll/ForecastTable/index.jsx
@@ -20,6 +20,12 @@ export default function ForecastTable({
     return matchingItems;
   }
 
+  const getClass = (index) => {
+    return previousMonths[index] && previousMonths[index].is_actual
+      ? "not-editable"
+      : "";
+  };
+
   return (
     <>
       <h2 className="govuk-heading-m">Payroll forecast</h2>
@@ -59,15 +65,17 @@ export default function ForecastTable({
                     {row.natural_account_code}
                   </th>
                   {months.map((month, index) => {
-                    let amount = formatMoney(row[month.toLowerCase()]);
+                    let amount = row[month.toLowerCase()];
                     if (actual && previousMonths[index].is_actual) {
-                      // Need to work out how the actuals amount needs to be formatted
-                      amount = actual[index].amount.toFixed(2);
+                      amount = actual[index].amount;
                     }
 
                     return (
-                      <td className="govuk-table__cell" key={month}>
-                        £{amount}
+                      <td
+                        className={`govuk-table__cell ${getClass(index)}`}
+                        key={month}
+                      >
+                        £{formatMoney(amount)}
                       </td>
                     );
                   })}

--- a/front_end/src/Components/EditPayroll/ForecastTable/index.jsx
+++ b/front_end/src/Components/EditPayroll/ForecastTable/index.jsx
@@ -17,8 +17,12 @@ export default function ForecastTable({ forecast, months }) {
               </th>
               {months.map((month) => {
                 return (
-                  <th scope="col" className="govuk-table__header" key={month}>
-                    {month}
+                  <th
+                    scope="col"
+                    className="govuk-table__header"
+                    key={month.key}
+                  >
+                    {month.short_name}
                   </th>
                 );
               })}
@@ -34,15 +38,14 @@ export default function ForecastTable({ forecast, months }) {
                   <th scope="row" className="govuk-table__header">
                     {row.natural_account_code}
                   </th>
-                  {months.map((month, index) => {
-                    const isActualClass =
-                      index < row.actuals_count ? "not-editable" : "";
+                  {months.map((month) => {
+                    const isActualClass = month.is_actual ? "not-editable" : "";
                     return (
                       <td
                         className={`govuk-table__cell ${isActualClass}`}
-                        key={month}
+                        key={month.key}
                       >
-                        £{formatMoney(row[month])}
+                        £{formatMoney(row[month.key])}
                       </td>
                     );
                   })}

--- a/front_end/src/Components/EditPayroll/ForecastTable/index.jsx
+++ b/front_end/src/Components/EditPayroll/ForecastTable/index.jsx
@@ -7,17 +7,17 @@ export default function ForecastTable({
   previousMonths,
 }) {
   function getMatchingActual(programme_code, natural_account_code) {
-    const matchingGroup = actuals.find(
+    const matchingProgrammeCode = actuals.find(
       (group) => group.programme_code === programme_code,
     );
-    let matchingItems = [];
-    if (matchingGroup) {
-      const matchingCode = matchingGroup.data.find(
+    let matchingActual = [];
+    if (matchingProgrammeCode) {
+      const matchingCode = matchingProgrammeCode.data.find(
         (n) => n.natural_account_code == natural_account_code,
       );
-      matchingItems = matchingCode ? matchingCode.items : [];
+      matchingActual = matchingCode ? matchingCode.items : [];
     }
-    return matchingItems;
+    return matchingActual;
   }
 
   const getClass = (index) => {
@@ -65,10 +65,10 @@ export default function ForecastTable({
                     {row.natural_account_code}
                   </th>
                   {months.map((month, index) => {
-                    let amount = row[month.toLowerCase()];
-                    if (actual && previousMonths[index].is_actual) {
-                      amount = actual[index].amount;
-                    }
+                    const amount =
+                      actual && previousMonths[index].is_actual
+                        ? actual[index].amount
+                        : row[month.toLowerCase()];
 
                     return (
                       <td

--- a/front_end/src/Components/EditPayroll/ForecastTable/index.jsx
+++ b/front_end/src/Components/EditPayroll/ForecastTable/index.jsx
@@ -1,31 +1,6 @@
 import { formatMoney } from "../../../Util";
 
-export default function ForecastTable({
-  forecast,
-  actuals,
-  months,
-  previousMonths,
-}) {
-  function getMatchingActual(programme_code, natural_account_code) {
-    const matchingProgrammeCode = actuals.find(
-      (group) => group.programme_code === programme_code,
-    );
-    let matchingActual = [];
-    if (matchingProgrammeCode) {
-      const matchingCode = matchingProgrammeCode.data.find(
-        (n) => n.natural_account_code == natural_account_code,
-      );
-      matchingActual = matchingCode ? matchingCode.items : [];
-    }
-    return matchingActual;
-  }
-
-  const getClass = (index) => {
-    return previousMonths[index] && previousMonths[index].is_actual
-      ? "not-editable"
-      : "";
-  };
-
+export default function ForecastTable({ forecast, months }) {
   return (
     <>
       <h2 className="govuk-heading-m">Payroll forecast</h2>
@@ -51,11 +26,6 @@ export default function ForecastTable({
           </thead>
           <tbody className="govuk-table__body">
             {forecast.map((row, index) => {
-              const actual = getMatchingActual(
-                row.programme_code,
-                row.natural_account_code,
-              );
-
               return (
                 <tr className="govuk-table__row" key={index}>
                   <th scope="row" className="govuk-table__header">
@@ -65,17 +35,14 @@ export default function ForecastTable({
                     {row.natural_account_code}
                   </th>
                   {months.map((month, index) => {
-                    const amount =
-                      actual && previousMonths[index].is_actual
-                        ? actual[index].amount
-                        : row[month.toLowerCase()];
-
+                    const isActualClass =
+                      index < row.actuals_count ? "not-editable" : "";
                     return (
                       <td
-                        className={`govuk-table__cell ${getClass(index)}`}
+                        className={`govuk-table__cell ${isActualClass}`}
                         key={month}
                       >
-                        £{formatMoney(amount)}
+                        £{formatMoney(row[month])}
                       </td>
                     );
                   })}

--- a/front_end/src/Components/EditPayroll/ForecastTable/index.jsx
+++ b/front_end/src/Components/EditPayroll/ForecastTable/index.jsx
@@ -1,6 +1,25 @@
 import { formatMoney } from "../../../Util";
 
-export default function ForecastTable({ forecast, months }) {
+export default function ForecastTable({
+  forecast,
+  actuals,
+  months,
+  previousMonths,
+}) {
+  function getMatchingActual(programme_code, natural_account_code) {
+    const matchingGroup = actuals.find(
+      (group) => group.programme_code === programme_code,
+    );
+    let matchingItems = [];
+    if (matchingGroup) {
+      const matchingCode = matchingGroup.data.find(
+        (n) => n.natural_account_code == natural_account_code,
+      );
+      matchingItems = matchingCode ? matchingCode.items : [];
+    }
+    return matchingItems;
+  }
+
   return (
     <>
       <h2 className="govuk-heading-m">Payroll forecast</h2>
@@ -26,6 +45,11 @@ export default function ForecastTable({ forecast, months }) {
           </thead>
           <tbody className="govuk-table__body">
             {forecast.map((row, index) => {
+              const actual = getMatchingActual(
+                row.programme_code,
+                row.natural_account_code,
+              );
+
               return (
                 <tr className="govuk-table__row" key={index}>
                   <th scope="row" className="govuk-table__header">
@@ -34,11 +58,19 @@ export default function ForecastTable({ forecast, months }) {
                   <th scope="row" className="govuk-table__header">
                     {row.natural_account_code}
                   </th>
-                  {months.map((month) => (
-                    <td className="govuk-table__cell" key={month}>
-                      £{formatMoney(row[month.toLowerCase()])}
-                    </td>
-                  ))}
+                  {months.map((month, index) => {
+                    let amount = formatMoney(row[month.toLowerCase()]);
+                    if (actual && previousMonths[index].is_actual) {
+                      // Need to work out how the actuals amount needs to be formatted
+                      amount = actual[index].amount.toFixed(2);
+                    }
+
+                    return (
+                      <td className="govuk-table__cell" key={month}>
+                        £{amount}
+                      </td>
+                    );
+                  })}
                 </tr>
               );
             })}

--- a/front_end/src/Util.js
+++ b/front_end/src/Util.js
@@ -165,6 +165,7 @@ export const processForecastData = (
     }
 
     const forecastKey = makeFinancialCodeKey(
+      "",
       rowData.programme,
       rowData.natural_account_code,
       rowData.analysis1_code,
@@ -207,6 +208,7 @@ const processPayrollData = (payrollData) => {
 
   for (const [key, value] of Object.entries(payrollData)) {
     const generatedKey = makeFinancialCodeKey(
+      "",
       value.programme_code,
       value.natural_account_code,
     );
@@ -217,14 +219,29 @@ const processPayrollData = (payrollData) => {
   return results;
 };
 
-const makeFinancialCodeKey = (
+export const makeFinancialCodeKey = (
+  costCentre,
   programme,
   nac,
-  analysis1 = null,
-  analysis2 = null,
-  project = null,
+  {
+    analysis1 = null,
+    analysis2 = null,
+    project = null,
+    year = null,
+    period = null,
+    separator = "/",
+  },
 ) => {
-  return `${programme}/${nac}/${analysis1}/${analysis2}/${project}`;
+  return [
+    costCentre,
+    programme,
+    nac,
+    analysis1,
+    analysis2,
+    project,
+    year,
+    period,
+  ].join(separator);
 };
 
 /**

--- a/front_end/src/Util.js
+++ b/front_end/src/Util.js
@@ -168,9 +168,11 @@ export const processForecastData = (
       "",
       rowData.programme,
       rowData.natural_account_code,
-      rowData.analysis1_code,
-      rowData.analysis2_code,
-      rowData.project_code,
+      {
+        analysis1: rowData.analysis1_code,
+        analysis2: rowData.analysis2_code,
+        project: rowData.project_code,
+      },
     );
 
     // eslint-disable-next-line
@@ -230,7 +232,7 @@ export const makeFinancialCodeKey = (
     year = null,
     period = null,
     separator = "/",
-  },
+  } = {},
 ) => {
   return [
     costCentre,

--- a/payroll/api.py
+++ b/payroll/api.py
@@ -34,8 +34,8 @@ class EditPayrollApiView(EditPayrollBaseView):
             )
         )
         previous_months = list(get_previous_months_data())
-        actuals = list(
-            payroll_service.get_actuals_data(self.cost_centre, self.financial_year)
+        actuals = payroll_service.get_actuals_data(
+            self.cost_centre, self.financial_year
         )
 
         return JsonResponse(

--- a/payroll/api.py
+++ b/payroll/api.py
@@ -34,6 +34,9 @@ class EditPayrollApiView(EditPayrollBaseView):
             )
         )
         previous_months = list(get_previous_months_data())
+        actuals = list(
+            payroll_service.get_actuals_data(self.cost_centre, self.financial_year)
+        )
 
         return JsonResponse(
             {
@@ -42,6 +45,7 @@ class EditPayrollApiView(EditPayrollBaseView):
                 "pay_modifiers": pay_modifiers,
                 "forecast": forecast,
                 "previous_months": previous_months,
+                "actuals": actuals,
             }
         )
 

--- a/payroll/services/payroll.py
+++ b/payroll/services/payroll.py
@@ -14,6 +14,7 @@ from core.constants import MONTHS
 from core.models import Attrition, FinancialYear, PayUplift
 from core.types import MonthsDict
 from costcentre.models import CostCentre
+from forecast.models import ForecastMonthlyFigure
 from forecast.utils.access_helpers import can_edit_cost_centre, can_edit_forecast
 from gifthospitality.models import Grade
 from user.models import User
@@ -418,6 +419,61 @@ def update_pay_modifiers_data(
             raise ValueError(ex)
 
         attrition.save()
+
+
+class Actuals(TypedDict):
+    id: int
+    natural_account_code: int
+    programme_code: int
+    amount: float
+    month: str
+
+
+def get_actuals_data(
+    cost_centre: CostCentre,
+    financial_year: FinancialYear,
+) -> Iterator[Actuals]:
+    nac_codes = [
+        settings.PAYROLL.BASIC_PAY_NAC,
+        settings.PAYROLL.PENSION_NAC,
+        settings.PAYROLL.ERNIC_NAC,
+    ]
+
+    qs = ForecastMonthlyFigure.objects.filter(
+        financial_year=financial_year,
+        financial_code__cost_centre=cost_centre,
+        financial_code__natural_account_code__natural_account_code__in=nac_codes,
+        financial_code__project_code__isnull=True,
+        archived_status__isnull=True,
+    ).select_related(
+        "financial_code__cost_centre",
+        "financial_code__natural_account_code",
+        "financial_code__project_code",
+    )
+
+    grouped = defaultdict(lambda: defaultdict(list))
+
+    for obj in qs:
+        programme_code = obj.financial_code.programme.programme_code
+        nac_code = obj.financial_code.natural_account_code.natural_account_code
+        grouped[programme_code][nac_code].append(
+            {
+                "id": obj.pk,
+                "natural_account_code": nac_code,
+                "programme_code": programme_code,
+                "amount": obj.amount,
+                "month": obj.financial_period.period_short_name,
+            }
+        )
+
+    for programme_code, nac_codes in grouped.items():
+        yield {
+            "programme_code": programme_code,
+            "data": [
+                {"natural_account_code": nac_code, "items": items}
+                for nac_code, items in nac_codes.items()
+            ],
+        }
 
 
 # Permissions

--- a/payroll/services/payroll.py
+++ b/payroll/services/payroll.py
@@ -458,7 +458,6 @@ def get_actuals_data(
         nac_code = obj.financial_code.natural_account_code.natural_account_code
         grouped[programme_code][nac_code].append(
             {
-                "id": obj.pk,
                 "natural_account_code": nac_code,
                 "programme_code": programme_code,
                 "amount": obj.amount,


### PR DESCRIPTION
Display actuals in the forecast table in Edit Payroll. Any cell that is an actual will be grey, similar to the Forecast tables.