### PR TITLE
FFT-145 Create attrition object from Edit Payroll

### DIFF
--- a/front_end/src/Apps/Payroll.jsx
+++ b/front_end/src/Apps/Payroll.jsx
@@ -96,9 +96,8 @@ export default function Payroll() {
   }
 
   function handleCreatePayModifiers() {
-    api.createPayModifiers().then((response) => {
-      console.log(response.data);
-      console.log(allPayroll);
+    api.createPayModifiers().then((r) => {
+      getAllPayroll();
     });
   }
 

--- a/front_end/src/Apps/Payroll.jsx
+++ b/front_end/src/Apps/Payroll.jsx
@@ -74,6 +74,7 @@ export default function Payroll() {
     try {
       await api.postPayrollData(allPayroll);
       setSaveSuccess(true);
+      setSaveError(false);
       getAllPayroll();
     } catch (error) {
       console.error("Error saving payroll: ", error);
@@ -95,8 +96,9 @@ export default function Payroll() {
   }
 
   function handleCreatePayModifiers() {
-    api.createPayModifiers().then((r) => {
-      getAllPayroll();
+    api.createPayModifiers().then((response) => {
+      console.log(response.data);
+      console.log(allPayroll);
     });
   }
 

--- a/front_end/src/Apps/Payroll.jsx
+++ b/front_end/src/Apps/Payroll.jsx
@@ -94,6 +94,12 @@ export default function Payroll() {
     dispatch({ type: "updatePayModifiers", id, index, value });
   }
 
+  function handleCreatePayModifiers() {
+    api.createPayModifiers().then((r) => {
+      getAllPayroll();
+    });
+  }
+
   function handleHidePreviousMonths() {
     setShowPreviousMonths(!showPreviousMonths);
 
@@ -157,6 +163,7 @@ export default function Payroll() {
           <EditPayModifier
             data={allPayroll.pay_modifiers}
             onInputChange={handleUpdatePayModifiers}
+            onCreate={handleCreatePayModifiers}
           />
         </Tab>
       </Tabs>

--- a/front_end/src/Components/EditPayroll/EditPayModifier/index.jsx
+++ b/front_end/src/Components/EditPayroll/EditPayModifier/index.jsx
@@ -1,8 +1,18 @@
 import { monthsToTitleCase } from "../../../Util";
 
-const EditPayModifier = ({ data, onInputChange }) => {
+const EditPayModifier = ({ data, onInputChange, onCreate }) => {
   if (data.length === 0) {
-    return <p className="govuk-body">No modifiers set</p>;
+    return (
+      <>
+        <p className="govuk-body">No modifiers set</p>
+        <button
+          className="govuk-button govuk-button--secondary"
+          onClick={onCreate}
+        >
+          Add Attrition
+        </button>
+      </>
+    );
   }
 
   return data.map((row, index) => (

--- a/front_end/src/Components/EditPayroll/api.js
+++ b/front_end/src/Components/EditPayroll/api.js
@@ -24,7 +24,7 @@ export function postPayrollData(payrollData) {
  * Create default pay modifier object
  */
 export function createPayModifiers() {
-  return getData(getPayrollApiUrl() + "pay_modifiers/");
+  return postData(getPayrollApiUrl() + "pay_modifiers/", {});
 }
 
 /**

--- a/front_end/src/Components/EditPayroll/api.js
+++ b/front_end/src/Components/EditPayroll/api.js
@@ -21,6 +21,13 @@ export function postPayrollData(payrollData) {
 }
 
 /**
+ * Create default pay modifier object
+ */
+export function createPayModifiers() {
+  return getData(getPayrollApiUrl() + "pay_modifiers/");
+}
+
+/**
  * Return the payroll API URL.
  *
  * This function relies on the `costCentreCode` and `financialYear` being available on

--- a/payroll/api.py
+++ b/payroll/api.py
@@ -68,10 +68,17 @@ class EditPayrollApiView(EditPayrollBaseView):
 
 
 class PayModifiersApiView(EditPayrollBaseView):
-    def get(self, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs):
         payroll_service.create_default_pay_modifiers(
             self.cost_centre,
             self.financial_year,
         )
 
-        return JsonResponse({})
+        pay_modifiers = list(
+            payroll_service.get_pay_modifiers_data(
+                self.cost_centre,
+                self.financial_year,
+            )
+        )
+
+        return JsonResponse({"pay_modifiers": pay_modifiers})

--- a/payroll/api.py
+++ b/payroll/api.py
@@ -65,3 +65,13 @@ class EditPayrollApiView(EditPayrollBaseView):
         )
 
         return JsonResponse({})
+
+
+class PayModifiersApiView(EditPayrollBaseView):
+    def get(self, request, *args, **kwargs):
+        payroll_service.create_default_pay_modifiers(
+            self.cost_centre,
+            self.financial_year,
+        )
+
+        return JsonResponse({})

--- a/payroll/api.py
+++ b/payroll/api.py
@@ -74,11 +74,4 @@ class PayModifiersApiView(EditPayrollBaseView):
             self.financial_year,
         )
 
-        pay_modifiers = list(
-            payroll_service.get_pay_modifiers_data(
-                self.cost_centre,
-                self.financial_year,
-            )
-        )
-
-        return JsonResponse({"pay_modifiers": pay_modifiers})
+        return JsonResponse({})

--- a/payroll/services/payroll.py
+++ b/payroll/services/payroll.py
@@ -360,10 +360,7 @@ def create_default_pay_modifiers(
     )
 
     if not qs.exists():
-        default_modifier = Attrition.objects.create(
-            cost_centre=cost_centre, financial_year=financial_year
-        )
-        Attrition.objects.filter(pk=default_modifier.pk)
+        Attrition.objects.create(cost_centre=cost_centre, financial_year=financial_year)
 
 
 @transaction.atomic

--- a/payroll/services/payroll.py
+++ b/payroll/services/payroll.py
@@ -350,6 +350,22 @@ def get_pay_modifiers_data(
         yield PayModifiers(id=obj.pk, pay_modifiers=obj.periods)
 
 
+def create_default_pay_modifiers(
+    cost_centre: CostCentre,
+    financial_year: FinancialYear,
+) -> None:
+    qs = Attrition.objects.filter(
+        cost_centre=cost_centre,
+        financial_year=financial_year,
+    )
+
+    if not qs.exists():
+        default_modifier = Attrition.objects.create(
+            cost_centre=cost_centre, financial_year=financial_year
+        )
+        Attrition.objects.filter(pk=default_modifier.pk)
+
+
 @transaction.atomic
 def update_pay_modifiers_data(
     cost_centre: CostCentre,

--- a/payroll/urls.py
+++ b/payroll/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 from forecast.views.edit_select_cost_centre import ChooseCostCentreView
-from payroll.api import EditPayrollApiView
+from payroll.api import EditPayrollApiView, PayModifiersApiView
 
 from . import views
 
@@ -18,6 +18,11 @@ urlpatterns = [
         "api/<str:cost_centre_code>/<int:financial_year>/",
         EditPayrollApiView.as_view(),
         name="api",
+    ),
+    path(
+        "api/<str:cost_centre_code>/<int:financial_year>/pay_modifiers/",
+        PayModifiersApiView.as_view(),
+        name="api_pay_modifiers",
     ),
     path(
         "edit/choose-cost-centre/",


### PR DESCRIPTION
If an Attrition object does not exist for a cost centre/financial year then there is a button to create one on the pay modifiers tab.

#### Screenshots
![Screenshot 2025-01-24 at 13 37 25](https://github.com/user-attachments/assets/9e58f217-1666-4256-97bf-071b961d2fd1)
