### PR TITLE
Fix previous months headers not hiding

### DIFF
--- a/front_end/src/Components/EditPayroll/PayrollTable/index.jsx
+++ b/front_end/src/Components/EditPayroll/PayrollTable/index.jsx
@@ -23,7 +23,7 @@ export default function PayrollTable({
             <tr className="govuk-table__row">
               {headers.map((header) => {
                 const isActual = previousMonths.some(
-                  (obj) => obj.month_short_name === header && obj.is_actual,
+                  (obj) => obj.short_name === header && obj.is_actual,
                 );
                 const isHidden =
                   showPreviousMonths && isActual ? " hidden" : "";

--- a/front_end/src/Components/EditPayroll/types.js
+++ b/front_end/src/Components/EditPayroll/types.js
@@ -33,7 +33,8 @@
 
 /**
  * @typedef {Object} PreviousMonthsData
- * @property {string} month_short_name - The short form name of the month
+ * @property {string} key - The short form name of the month in lowercase
+ * @property {string} short_name - The short form name of the month in titlecase
  * @property {int} month_index - The financial index of the month (Apr is 1 etc)
  * @property {bool} is_actual - Is the actual loaded for this month
  */

--- a/front_end/src/Components/EditPayroll/types.js
+++ b/front_end/src/Components/EditPayroll/types.js
@@ -35,7 +35,7 @@
  * @typedef {Object} PreviousMonthsData
  * @property {string} key - The short form name of the month in lowercase
  * @property {string} short_name - The short form name of the month in titlecase
- * @property {int} month_index - The financial index of the month (Apr is 1 etc)
+ * @property {int} index - The financial index of the month (Apr is 1 etc)
  * @property {bool} is_actual - Is the actual loaded for this month
  */
 


### PR DESCRIPTION
The logic to hide headers for previous months was using an old reference to the month name and therefore not matching on any that should be hidden