### PR TITLE
Fix error to log internally

### DIFF
--- a/forecast/views/edit_forecast.py
+++ b/forecast/views/edit_forecast.py
@@ -335,8 +335,9 @@ class PasteForecastRowsView(
                 CannotFindForecastMonthlyFigureException,
                 IncorrectDecimalFormatException,
             ) as ex:
+                logger.error(f"Exception occurred: {ex}", exc_info=True)
                 return JsonResponse(
-                    {"error": str(ex)},
+                    {"error": "An error occurred while pasting your data"},
                     status=400,
                 )
 

--- a/forecast/views/edit_forecast.py
+++ b/forecast/views/edit_forecast.py
@@ -335,7 +335,10 @@ class PasteForecastRowsView(
                 CannotFindForecastMonthlyFigureException,
                 IncorrectDecimalFormatException,
             ) as ex:
-                logger.error(f"Exception occurred: {ex}", exc_info=True)
+                logger.fatal(
+                    f"Error when pasting forecast data {ex}",
+                    exc_info=True,
+                )
                 return JsonResponse(
                     {"error": "An error occurred while pasting your data"},
                     status=400,


### PR DESCRIPTION
Fix for code scan error of `Information exposure through an exception`.
Updated to log the error internally and the JsonResponse is now generic