### PR TITLE
Bug - Remove excess pound sign

### DIFF
--- a/front_end/src/Components/EditPayroll/ForecastTable/index.jsx
+++ b/front_end/src/Components/EditPayroll/ForecastTable/index.jsx
@@ -47,7 +47,7 @@ export default function ForecastTable({ forecast, months }) {
                         className={`govuk-table__cell ${isActualClass}`}
                         key={month.key}
                       >
-                        £{formatMoney(row[month.key] ?? 0)}
+                        {formatMoney(row[month.key] ?? 0)}
                       </td>
                     );
                   })}


### PR DESCRIPTION
Forecast table on payroll has 1an extra pound sign next to currency