### PR TITLE
Bug: Update Tanstack table to take unique table id for id fields

### DIFF
--- a/front_end/src/Apps/Payroll.jsx
+++ b/front_end/src/Apps/Payroll.jsx
@@ -31,16 +31,10 @@ export default function Payroll() {
     payrollReducer,
     initialPayrollState,
   );
-  const initialShowPreviousMonths = localStorage.getItem(
-    "editPayroll.showPreviousMonths",
-  );
 
   // State
 
   const [isLoading, setIsLoading] = useState(true);
-  const [showPreviousMonths, setShowPreviousMonths] = useState(
-    initialShowPreviousMonths === "true",
-  );
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [errors, setErrors] = useState(null);
   const [activeTab, setActiveTab] = useState(() => {
@@ -144,15 +138,6 @@ export default function Payroll() {
     api.createPayModifiers().then((r) => {
       getAllPayroll();
     });
-  }
-
-  function handleHidePreviousMonths() {
-    setShowPreviousMonths(!showPreviousMonths);
-
-    localStorage.setItem(
-      "editPayroll.showPreviousMonths",
-      JSON.stringify(!showPreviousMonths),
-    );
   }
 
   if (isLoading) {

--- a/front_end/src/Apps/Payroll.jsx
+++ b/front_end/src/Apps/Payroll.jsx
@@ -173,6 +173,7 @@ export default function Payroll() {
               allPayroll.previous_months,
             )}
             previousMonths={allPayroll.previous_months}
+            tableId="payroll"
           />
         </Tab>
         <Tab label="Non-payroll" key="2">
@@ -184,6 +185,7 @@ export default function Payroll() {
               allPayroll.previous_months,
             )}
             previousMonths={allPayroll.previous_months}
+            tableId="non-payroll"
           />
         </Tab>
         <Tab label="Vacancies" key="3">
@@ -195,6 +197,7 @@ export default function Payroll() {
               allPayroll.previous_months,
             )}
             previousMonths={allPayroll.previous_months}
+            tableId="vacancies"
           />
           <a
             className="govuk-button govuk-!-margin-right-2 govuk-button--secondary"

--- a/front_end/src/Components/EditPayroll/TanstackTable/index.jsx
+++ b/front_end/src/Components/EditPayroll/TanstackTable/index.jsx
@@ -18,8 +18,6 @@ function TanstackTable({ data, columns, previousMonths, tableId }) {
   const [sorting, setSorting] = useState([]);
   const [showPreviousMonths, setShowPreviousMonths] = useState(true);
 
-  console.log(data);
-
   // Table state
   const table = useReactTable({
     data,

--- a/front_end/src/Components/EditPayroll/TanstackTable/index.jsx
+++ b/front_end/src/Components/EditPayroll/TanstackTable/index.jsx
@@ -12,11 +12,13 @@ import SortDownIcon from "../../../../icons/sort-down.svg?react";
 import UnsortedIcon from "../../../../icons/unsorted.svg?react";
 import ToggleCheckbox from "../../Common/ToggleCheckbox";
 
-function TanstackTable({ data, columns, previousMonths }) {
+function TanstackTable({ data, columns, previousMonths, tableId }) {
   // State
   const [globalFilter, setGlobalFilter] = useState("");
   const [sorting, setSorting] = useState([]);
   const [showPreviousMonths, setShowPreviousMonths] = useState(true);
+
+  console.log(data);
 
   // Table state
   const table = useReactTable({
@@ -55,12 +57,12 @@ function TanstackTable({ data, columns, previousMonths }) {
     <div className="tanstack-table scrollable">
       <div className="table-options">
         <div className="govuk-form-group">
-          <label className="govuk-label" htmlFor="search">
+          <label className="govuk-label" htmlFor={`${tableId}-search`}>
             Search
           </label>
           <input
             type="text"
-            id="search"
+            id={`${tableId}-search`}
             value={globalFilter}
             onChange={(e) => setGlobalFilter(e.target.value)}
             placeholder="Search rows..."
@@ -70,8 +72,8 @@ function TanstackTable({ data, columns, previousMonths }) {
         <ToggleCheckbox
           toggle={showPreviousMonths}
           handler={togglePreviousMonthsVisibility}
-          id="payroll-previous-months"
-          value="payroll-previous-months"
+          id={`${tableId}-previous-months`}
+          value={`${tableId}-previous-months`}
           label="Show previous months"
         />
       </div>


### PR DESCRIPTION
The checkbox for Previous Months was not working properly.
You could only click on the label to activate the checkbox for the Payroll tab. This did not work for the Non-Payroll and Vacancies checkbox as it had the same id/ for tag as the first checkbox.

I've updated this for the search box also so that it can be differentiated by accessibility tools.

Also removed unused previous months code
