### PR TITLE
FFT-207 Change go to payroll / forecast links to buttons

### DIFF
--- a/forecast/templates/forecast/edit/edit.html
+++ b/forecast/templates/forecast/edit/edit.html
@@ -28,7 +28,7 @@
             {% can_access_edit_payroll user as user_can_access_edit_payroll %}
             {% switch 'payroll' %}
                 {% if user_can_access_edit_payroll %}
-                    <a class="govuk-button govuk-button--secondary" href="{% url 'payroll:edit' view.cost_centre_details.cost_centre_code view.financial_year %}">Go to Payroll</a>
+                    <a class="govuk-button govuk-button--secondary" href="{% url 'payroll:edit' view.cost_centre_details.cost_centre_code view.financial_year %}">Go to payroll</a>
                 {% endif %}
             {% endswitch %}
         </div>

--- a/forecast/templates/forecast/edit/edit.html
+++ b/forecast/templates/forecast/edit/edit.html
@@ -12,18 +12,6 @@
 
 {% block title %}Edit Forecast{% endblock %}
 
-{% block page_heading %}
-<div style="display: flex; align-items: baseline; gap: 2rem;">
-    {{ block.super }}
-    {% can_access_edit_payroll user as user_can_access_edit_payroll %}
-    {% switch 'payroll' %}
-        {% if user_can_access_edit_payroll %}
-            <a class="govuk-link govuk-link--no-visited-state" href="{% url 'payroll:edit' view.cost_centre_details.cost_centre_code view.financial_year %}">Go to Payroll</a>
-        {% endif %}
-    {% endswitch %}
-</div>
-{% endblock %}
-
 {% block page_content %}
     <div class="govuk-grid-row date-selection-download">
 
@@ -37,6 +25,12 @@
             <a id="download_forecast" class="govuk-button govuk-button--secondary" data-module="govuk-button" href="{% url 'export_edit_forecast_data_cost_centre' view.cost_centre_details.cost_centre_code  view.financial_year %}">
                 Download
             </a>
+            {% can_access_edit_payroll user as user_can_access_edit_payroll %}
+            {% switch 'payroll' %}
+                {% if user_can_access_edit_payroll %}
+                    <a class="govuk-button govuk-button--secondary" href="{% url 'payroll:edit' view.cost_centre_details.cost_centre_code view.financial_year %}">Go to Payroll</a>
+                {% endif %}
+            {% endswitch %}
         </div>
     </div>
 

--- a/front_end/src/Apps/Payroll.jsx
+++ b/front_end/src/Apps/Payroll.jsx
@@ -148,6 +148,19 @@ export default function Payroll() {
     <>
       {saveSuccess && <SuccessBanner>Success - forecast updated</SuccessBanner>}
       {errors && <ErrorSummary errors={errors} />}
+      <div className="govuk-form-group">
+        <button className="govuk-button" onClick={handleSavePayroll}>
+          Save changes
+        </button>
+        {window.FEATURES.payroll && (
+          <a
+            className="govuk-button govuk-button--secondary govuk-!-margin-left-4"
+            href={window.forecastUrl}
+          >
+            Go to forecast
+          </a>
+        )}
+      </div>
       <Tabs activeTab={activeTab} setActiveTab={setActiveTab}>
         <Tab label="Payroll" key="1">
           <TanstackTable
@@ -206,9 +219,6 @@ export default function Payroll() {
           </div>
         </Tab>
       </Tabs>
-      <button className="govuk-button" onClick={handleSavePayroll}>
-        Save payroll and update forecast
-      </button>
       <ForecastTable
         forecast={forecastAndActuals}
         months={allPayroll.previous_months}

--- a/front_end/src/Apps/Payroll.jsx
+++ b/front_end/src/Apps/Payroll.jsx
@@ -152,14 +152,12 @@ export default function Payroll() {
         <button className="govuk-button" onClick={handleSavePayroll}>
           Save changes
         </button>
-        {window.FEATURES.payroll && (
-          <a
-            className="govuk-button govuk-button--secondary govuk-!-margin-left-4"
-            href={window.forecastUrl}
-          >
-            Go to forecast
-          </a>
-        )}
+        <a
+          className="govuk-button govuk-button--secondary govuk-!-margin-left-4"
+          href={window.forecastUrl}
+        >
+          Go to forecast
+        </a>
       </div>
       <Tabs activeTab={activeTab} setActiveTab={setActiveTab}>
         <Tab label="Payroll" key="1">

--- a/payroll/templates/payroll/page/edit_payroll.html
+++ b/payroll/templates/payroll/page/edit_payroll.html
@@ -1,5 +1,5 @@
 {% extends "base_generic.html" %}
-{% load breadcrumbs vite forecast_format waffle_tags %}
+{% load breadcrumbs vite forecast_format %}
 
 {% block title %}Edit payroll{% endblock title %}
 
@@ -12,11 +12,6 @@
 {% block content %}
     <div class="flex-spread">
         <h1 class="govuk-heading-l">Edit payroll</h1>
-
-        {# Here we assume that a user with access to payroll also has access to forecast #}
-        {% switch 'payroll' %}
-            <a class="govuk-link govuk-link--no-visited-state" href="{% url 'edit_forecast' cost_centre.cost_centre_code financial_year.financial_year %}">Go to Forecast</a>
-        {% endswitch %}
     </div>
 
     <h2 class="govuk-heading-m">
@@ -31,6 +26,7 @@
         window.costCentreCode = "{{ cost_centre.cost_centre_code|escapejs }}";
         window.financialYear = new Number("{{ financial_year.financial_year }}");
         window.addVacancyUrl = "{% url 'payroll:add_vacancy' cost_centre.cost_centre_code financial_year.financial_year %}"
+        window.forecastUrl = "{% url 'edit_forecast' cost_centre.cost_centre_code financial_year.financial_year %}"
     </script>
     {% vite_dev_client %}
     {% vite_js 'src/index.jsx' %}


### PR DESCRIPTION
- Go to payroll / forecast links are now buttons
- Save button has new text and has moved above the tabs

#### Screenshots

![Screenshot 2025-03-31 at 13 35 40](https://github.com/user-attachments/assets/09b54532-de62-4266-acd6-d15548249b20)

![Screenshot 2025-03-31 at 13 36 58](https://github.com/user-attachments/assets/5a59ce81-9dfe-4732-9802-fc74380579b0)

