### PR TITLE
FFT-301 Lock off attrition

### DIFF
--- a/front_end/src/Apps/Payroll.jsx
+++ b/front_end/src/Apps/Payroll.jsx
@@ -176,7 +176,7 @@ export default function Payroll() {
         </Tab>
         <Tab label="Non-payroll" key="2">
           <div className="govuk-grid-row">
-            <div className="govuk-grid-column-two-thirds">
+            <div className="govuk-grid-column-two-thirds limit-text-width">
               <p className="govuk-body">
                 Non-payroll includes staff on maternity leave,{" "}
                 <a

--- a/front_end/src/Components/EditPayroll/DisplayAttrition/index.jsx
+++ b/front_end/src/Components/EditPayroll/DisplayAttrition/index.jsx
@@ -49,11 +49,11 @@ const DisplayAttrition = ({
           modifier={global_attrition}
           title="Global attrition"
         />
-        <p className="govuk-body">
+        {/* TODO (FFT-301): Lock off Attrition */}
+        {/* <p className="govuk-body">
           This attrition is for the current financial year. You can add one for
           this specific cost centre instead.
-        </p>
-        {/* TODO (FFT-301): Lock off Attrition */}
+        </p> */}
         {/* <button
           className="govuk-button govuk-button--secondary"
           onClick={onCreate}
@@ -87,7 +87,7 @@ const Description = () => {
         <div className="govuk-grid-column-two-thirds limit-text-width">
           <p className="govuk-body">
             Attrition rate is the rate in which staff leave an organisation over
-            a year. DBT sets a default rate.
+            a year. The default rate is set by the Systems and Reporting team.
           </p>
           {/* TODO (FFT-301): Lock off Attrition */}
           {/* <p className="govuk-body">

--- a/front_end/src/Components/EditPayroll/DisplayAttrition/index.jsx
+++ b/front_end/src/Components/EditPayroll/DisplayAttrition/index.jsx
@@ -53,12 +53,13 @@ const DisplayAttrition = ({
           This attrition is for the current financial year. You can add one for
           this specific cost centre instead.
         </p>
-        <button
+        {/* TODO (FFT-301): Lock off Attrition */}
+        {/* <button
           className="govuk-button govuk-button--secondary"
           onClick={onCreate}
         >
           Add Attrition
-        </button>
+        </button> */}
       </>
     );
   }
@@ -67,12 +68,13 @@ const DisplayAttrition = ({
     <>
       <Description />
       <p className="govuk-body">No attrition set</p>
-      <button
+      {/* TODO (FFT-301): Lock off Attrition */}
+      {/* <button
         className="govuk-button govuk-button--secondary"
         onClick={onCreate}
       >
         Add Attrition
-      </button>
+      </button> */}
     </>
   );
 };
@@ -82,12 +84,17 @@ const Description = () => {
     <>
       <h3 className="govuk-heading-s">Attrition rate</h3>
       <div className="govuk-grid-row">
-        <div className="govuk-grid-column-two-thirds">
+        <div className="govuk-grid-column-two-thirds limit-text-width">
           <p className="govuk-body">
+            Attrition rate is the rate in which staff leave an organisation over
+            a year. DBT sets a default rate.
+          </p>
+          {/* TODO (FFT-301): Lock off Attrition */}
+          {/* <p className="govuk-body">
             Attrition rate is the rate in which staff leave an organisation over
             a year. DBT sets a default rate of X% but you can override it for
             your cost centre.
-          </p>
+          </p> */}
         </div>
       </div>
     </>

--- a/front_end/src/Components/EditPayroll/DisplayAttrition/index.jsx
+++ b/front_end/src/Components/EditPayroll/DisplayAttrition/index.jsx
@@ -87,14 +87,15 @@ const Description = () => {
         <div className="govuk-grid-column-two-thirds limit-text-width">
           <p className="govuk-body">
             Attrition rate is the rate in which staff leave an organisation over
-            a year. The default rate is set by the Systems and Reporting team.
+            a year. The default rate is set by the{" "}
+            <a
+              className="govuk-link"
+              href="https://workspace.trade.gov.uk/teams/financial-reporting-and-analysis/"
+            >
+              Systems and Reporting team
+            </a>
+            .
           </p>
-          {/* TODO (FFT-301): Lock off Attrition */}
-          {/* <p className="govuk-body">
-            Attrition rate is the rate in which staff leave an organisation over
-            a year. DBT sets a default rate of X% but you can override it for
-            your cost centre.
-          </p> */}
         </div>
       </div>
     </>


### PR DESCRIPTION
Attrition creation is locked off so that cost centre scoped attrition cannot be created by users.