### PR TITLE
FFT-318 Fix orphaned payroll forecasts

### DIFF
--- a/forecast/import_actuals.py
+++ b/forecast/import_actuals.py
@@ -376,9 +376,11 @@ def actualisation(
             financial_year=year,
             financial_period_id=period.pk + i + 1,
             archived_status=None,
-            defaults={"amount": difference},
+            defaults={"amount": difference, "starting_amount": difference},
         )
 
         if not created:
-            obj.amount = obj.amount + difference
+            new_amount = obj.amount + difference
+            obj.amount = new_amount
+            obj.starting_amount = new_amount
             obj.save()

--- a/forecast/models.py
+++ b/forecast/models.py
@@ -1,5 +1,6 @@
 import copy
 import hashlib
+from typing import Self
 
 import waffle
 from django.conf import settings
@@ -1031,6 +1032,20 @@ class ForecastingDataView(ForecastingDataViewAbstract):
         db_table = "forecast_forecast_download_view"
 
 
+class MonthlyFigureQuerySet(models.QuerySet):
+    def forecast(self, financial_year: FinancialYear) -> Self:
+        """Filter on the figure being a forecast based on the given financial year."""
+        qs = self.filter(
+            financial_year=financial_year,
+            archived_status__isnull=True,
+        )
+
+        if financial_year.current:
+            qs = self.filter(financial_period__actual_loaded=False)
+
+        return qs
+
+
 class MonthlyFigureAbstract(BaseModel):
     """It contains the forecast and the actuals.
     The current month defines what is Actual and what is Forecast"""
@@ -1052,7 +1067,7 @@ class MonthlyFigureAbstract(BaseModel):
         on_delete=models.PROTECT,
         related_name="%(app_label)s_%(class)ss",
     )
-    objects = models.Manager()  # The default manager.
+    objects = MonthlyFigureQuerySet.as_manager()
     pivot = PivotManager()
 
     # TODO don't save to month that have actuals

--- a/payroll/management/commands/update_payroll_forecast.py
+++ b/payroll/management/commands/update_payroll_forecast.py
@@ -12,9 +12,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         year = options["financial_year"]
 
-        msg = f"Updating all payroll forecasts for {year}"
-        self.stdout.write(self.style.SUCCESS(msg))
-
+        self.stdout.write(f"Updating all payroll forecasts for {year}")
         update_all_payroll_forecast(financial_year=year)
 
         self.stdout.write(self.style.SUCCESS("Done"))

--- a/payroll/models.py
+++ b/payroll/models.py
@@ -15,6 +15,9 @@ class EmployeeQuerySet(models.QuerySet):
     def payroll(self):
         return self.filter(basic_pay__gt=0)
 
+    def current(self):
+        return self.filter(has_left=False)
+
 
 class VacancyQuerySet(models.QuerySet):
     def prefetch_pay_periods(self, **filters):

--- a/payroll/test_data/payroll.csv
+++ b/payroll/test_data/payroll.csv
@@ -1,0 +1,2 @@
+employee_no,first_name,last_name,cost_centre,programme_code,grade,assignment_status,fte,basic_pay,ernic,pension
+13000001,Test,Employee,888813,338888,Grade 7,Active Assignment,1.0,240000,12000,7600

--- a/payroll/tests/factories.py
+++ b/payroll/tests/factories.py
@@ -26,6 +26,9 @@ class EmployeeFactory(factory.django.DjangoModelFactory):
     grade = factory.SubFactory(GradeFactory)
     fte = 1.0
     assignment_status = "Active Assignment"
+    basic_pay = factory.fuzzy.FuzzyInteger(low=1000_00, high=3000_00)
+    ernic = factory.fuzzy.FuzzyInteger(low=50_00, high=250_00)
+    pension = factory.fuzzy.FuzzyInteger(low=100_00, high=300_00)
 
 
 class EmployeePayPeriodsFactory(factory.django.DjangoModelFactory):

--- a/payroll/tests/services/test_payroll.py
+++ b/payroll/tests/services/test_payroll.py
@@ -85,6 +85,9 @@ def test_payroll_forecast(db, payroll_nacs):
         cost_centre=cost_centre,
         programme_code__programme_code="123456",
         grade__grade="Grade 7",
+        basic_pay=0,
+        pension=0,
+        ernic=0,
     )
 
     # TODO: Consider an ergonomic way of avoiding this pattern all the time.
@@ -406,3 +409,79 @@ def test_average_cost_for_grade(db):
         pension=50000,
     )
     assert employee_cost == expected
+
+
+def test_update_all_payroll_forecast_removes_orphaned_figures(
+    db, current_financial_year, payroll_nacs
+):
+    prog_1 = ProgrammeCodeFactory(programme_code="123456")
+    prog_2 = ProgrammeCodeFactory(programme_code="654321")
+
+    employee = EmployeeFactory(programme_code=prog_1)
+    employee_created(employee)
+
+    payroll_fin_code_1 = FinancialCodeFactory(
+        cost_centre=employee.cost_centre,
+        programme=prog_1,
+        natural_account_code__natural_account_code=SALARY_NAC,
+    )
+    payroll_fin_code_2 = FinancialCodeFactory(
+        cost_centre=employee.cost_centre,
+        programme=prog_2,
+        natural_account_code__natural_account_code=SALARY_NAC,
+    )
+
+    # create a forecast against a non-payroll NAC
+    other_fin_code_2 = FinancialCodeFactory(
+        cost_centre=employee.cost_centre,
+        programme=prog_2,
+    )
+    ForecastMonthlyFigure.objects.create(
+        financial_year=current_financial_year,
+        financial_period_id=1,
+        financial_code=other_fin_code_2,
+        amount=999_99,
+    )
+
+    update_payroll_forecast(
+        financial_year=current_financial_year,
+        cost_centre=employee.cost_centre,
+    )
+
+    # move all employee's to a different programme code
+    employee.programme_code = prog_2
+    employee.save()
+
+    update_payroll_forecast(
+        financial_year=current_financial_year,
+        cost_centre=employee.cost_centre,
+    )
+
+    forecast_figures_1 = (
+        ForecastMonthlyFigure.objects.filter(
+            financial_year=current_financial_year,
+            financial_code=payroll_fin_code_1,
+            archived_status=None,
+        )
+        .order_by("financial_period")
+        .values_list("amount", flat=True)
+    )
+    forecast_figures_2 = (
+        ForecastMonthlyFigure.objects.filter(
+            financial_year=current_financial_year,
+            financial_code=payroll_fin_code_2,
+            archived_status=None,
+        )
+        .order_by("financial_period")
+        .values_list("amount", flat=True)
+    )
+
+    # orphan forecasts have been removed
+    assert list(forecast_figures_1) == []
+    # new forecasts have been created
+    assert list(forecast_figures_2) == [employee.basic_pay] * 12
+    # non-payroll (other) forecasts were not changed
+    assert (
+        ForecastMonthlyFigure.objects.filter(financial_code=other_fin_code_2).count()
+        == 1
+    )

--- a/payroll/tests/services/test_payroll.py
+++ b/payroll/tests/services/test_payroll.py
@@ -432,14 +432,14 @@ def test_update_all_payroll_forecast_removes_orphaned_figures(
     )
 
     # create a forecast against a non-payroll NAC
-    other_fin_code_2 = FinancialCodeFactory(
+    other_fin_code = FinancialCodeFactory(
         cost_centre=employee.cost_centre,
         programme=prog_2,
     )
     ForecastMonthlyFigure.objects.create(
         financial_year=current_financial_year,
         financial_period_id=1,
-        financial_code=other_fin_code_2,
+        financial_code=other_fin_code,
         amount=999_99,
     )
 
@@ -482,6 +482,5 @@ def test_update_all_payroll_forecast_removes_orphaned_figures(
     assert list(forecast_figures_2) == [employee.basic_pay] * 12
     # non-payroll (other) forecasts were not changed
     assert (
-        ForecastMonthlyFigure.objects.filter(financial_code=other_fin_code_2).count()
-        == 1
+        ForecastMonthlyFigure.objects.filter(financial_code=other_fin_code).count() == 1
     )


### PR DESCRIPTION
Orphaned payroll forecasts would occur when a financial code no being driven by the payroll forecast. This would usually happen when a vacancy was created with one programme code and then switched to another. If the first programme code was no longer used by any employee or vacancy in that cost centre, the forecast for that financial code would be left, causing the numbers to be wrong.

The solution is to remove any forecasts which are orphaned when the payroll forecast of a cost centre is updated.