### PR TITLE
FFT-363 Remove auto focus on error summary

### DIFF
--- a/upload_file/templates/upload_file/uploaded_files.html
+++ b/upload_file/templates/upload_file/uploaded_files.html
@@ -34,7 +34,7 @@
             {% for document in view.uploaded_files %}
             <div class="govuk-grid-row">
                 {% if document.status == "error" or document.status == "parsing" or document.status == "processed_error" %}
-                    <div class="govuk-error-summary" aria-labelledby="error-summary-title" data-module="govuk-error-summary">
+                    <div class="govuk-error-summary" aria-labelledby="error-summary-title" tabindex="0">
                       <h2 class="govuk-error-summary__title" id="error-summary-title">
                         There was a problem processing this file
                       </h2>
@@ -48,8 +48,8 @@
                     </div>
                 {% endif %}
                 {% if document.status == "processed_warning" %}
-                    <div class="govuk-error-summary" aria-labelledby="error-summary-title" data-module="govuk-error-summary">
-                      <h2 class="govuk-error-summary__title" id="error-summary-title">
+                    <div class="govuk-error-summary" aria-labelledby="error-summary-title">
+                      <h2 class="govuk-error-summary__title" id="error-summary-title" tabindex="0">
                         The file was uploaded, but some warnings have been found:
                       </h2>
                       <div class="govuk-error-summary__body">

--- a/upload_split_file/templates/split_projects.html
+++ b/upload_split_file/templates/split_projects.html
@@ -41,7 +41,7 @@
             {% for document in view.uploaded_files %}
             <div class="govuk-grid-row">
                 {% if document.status == "error" or document.status == "parsing" or document.status == "processed_error" %}
-                    <div class="govuk-error-summary" aria-labelledby="error-summary-title" data-module="govuk-error-summary">
+                    <div class="govuk-error-summary" aria-labelledby="error-summary-title" tabindex="0">
                       <h2 class="govuk-error-summary__title" id="error-summary-title">
                         There was a problem processing this file
                       </h2>
@@ -55,7 +55,7 @@
                     </div>
                 {% endif %}
                 {% if document.status == "processed_warning" %}
-                    <div class="govuk-error-summary" aria-labelledby="error-summary-title" data-module="govuk-error-summary">
+                    <div class="govuk-error-summary" aria-labelledby="error-summary-title" tabindex="0">
                       <h2 class="govuk-error-summary__title" id="error-summary-title">
                         The file was uploaded, but some warnings have been found:
                       </h2>


### PR DESCRIPTION
- Remove data-module to prevent auto focus
- Add tabindex so error summaries can be tabbed to via keyboard